### PR TITLE
Add three research notes on future of work and AI

### DIFF
--- a/_notes/distribution-vs-depth.md
+++ b/_notes/distribution-vs-depth.md
@@ -1,0 +1,117 @@
+---
+layout: note
+title: "Distribution vs Depth: Thoughts on Learning Reinvestment"
+date: 2025-01-15
+tags: [leverage, learning, consulting, productization, agency-work]
+attribution: human-written
+---
+
+We love our agency clients, and we love building bespoke answers to their specific needs. But, as we think about the next phase of ThinkNimble and how to extend our impact beyond the hundreds of excellent entrepreneurs we've worked with, we're asking: how can we use the Agency for a larger good? We've built hundreds of apps and provided leverage to our entreprenuers. We've learned a lot along the way. But for every learning we've had, it's extremely difficult to reinvest it. How do you extract the deep, narrow insights from bespoke client work and transform them into broadly applicable solutions? If we could do that well, how would that change our scale of impact?
+
+## The Leverage Problem
+
+When we started ThinkNimble, we thought that by working with dozens of entreprenuers with hundreds or thousands of clients each, we could have outsize impact with our time. That hasn't panned out. Starting a company is extremely hard. Only a few survive, and that can have everything to do with timing, connections, competition, and nothing to do with skill or idea or effort or tech. As we think about what's next, what can we learn from our leverage, or lack thereof, in the last 10 years, and build a new paradigm moving forward?
+
+<div class="conversation">
+  <div class="conversation-message">
+    <strong>William</strong><span class="conversation-timestamp">Monday at 3:47 PM</span>
+    <p>That triangle [from Every] reminded me of this triangle from Alex Hormozi</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>William</strong><span class="conversation-timestamp">3:49</span>
+    <p>Except the scale is reversed, and the core idea behind the triangle is different. Every's triangle is like a monetization funnel. This triangle is more about leverage. Consulting (like what we do in the agency) is very time-intensive for the money, while capital, code, and content all scale better</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">5:27</span>
+    <p>I agree it's more like monetization funnel, and I feel like you shared this idea of leverage in the past. It resonates, especially in the "work once, 1m people see what you've done" way. but I was more thinking of a learning triangle, shall we say.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">5:27</span>
+    <p>Working hands on with a few clients in the agency gives us the opportunity to make deep, narrow impact, and learn a lot about a very specific topic. As we go up the triangle (probably losing this metaphor a bit but), we get broader applicability, and shallower application. But, if we can hone and refine our ideas well in the agency portion, it can power the applicability of our solutions to many people (and hopefully deepens those solutions because we find 10,000 people who have the exact same problem that's solved by agent launcher as applied to the PT firm for example). This is probably a different metric than leverage, but part of what resonated about the triangle for me.</p>
+  </div>
+</div>
+
+### Why We Haven't Built Leverage
+
+<div class="conversation">
+  <div class="conversation-message">
+    <strong>William</strong><span class="conversation-timestamp">9/30/25 at 9:39 AM</span>
+    <p>It's ironic/frustrating/discouraging to me that a core part of what we do is build software - which should be the ultimate modern leverage - but almost ten years in, and we're still doing a lot of things ourselves. We get "leverage" from our skills in the sense that we can "produce value" faster than competitors. So we can work less and earn more than average, but the lever doesn't really exist outside of us.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">9:39</span>
+    <p>I think we spend so much time solving the deep intricacies of other people's problems, without extrapolating those solutions, so we've always been unable to capitalize on the leverage we build for other people. For example - a consulting firm will recognize let's say 25% efficiency gains from the software we built. But, we get maybe 3% more efficient because of updates we make to the bootstrapper from the product.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">9:39</span>
+    <p>If we took that product and repackaged it, stripped out the most customized parts, and then found 30 other consulting firms with a huge problem with SF -> Decipher integrations, we'd be able to recognize leverage from that time we spent.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">9:39</span>
+    <p>I agree with you, but I wonder if it's somewhat a byproduct of running a bespoke company that prevents us from building that leverage.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>William</strong><span class="conversation-timestamp">9:57 AM</span>
+    <p>Yes, exactly.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">9:59 AM</span>
+    <p>A cool bet for the new year would be that if we take an agency client on, we have to be able to find 50 other people the solution could apply to, and then directly market a generic version of our solution to them or something.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Neil</strong><span class="conversation-timestamp">10:00 AM</span>
+    <p>I like that. Or at the very least identifying the "reusable, high-leverage" portions of any client and prioritizing them based on that.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">10:03 AM</span>
+    <p>Yeah, I'm positive we could find more Consulting firms based on the solution we built. Similar with AI-first analysis companies. Other current clients are pretty bespoke.</p>
+  </div>
+</div>
+
+## Two Triangles
+
+**Hormozi's Leverage Triangle**: Time → Code/Capital/Content (ascending leverage)
+- Bottom: Consulting (time-intensive)
+- Top: Capital, code, content (scale without more time)
+
+**Our Learning Triangle**: Deep → Productized → Scaled
+- Bottom: Deep agency work (1-5 clients, bespoke solutions, maximum learning depth) [this is where we've lived for 10 years]
+- Middle: Productized services (50-100 similar clients, templated approach, pattern recognition) [we've dabbled here]
+- Top: Scaled products (1:∞ scale) [the dream]
+
+The key insight: These triangles should feed each other. Deep work generates insights that become productized services that become scaled products. Without intentional extraction, you stay trapped at the bottom. [Ask me how I know.]
+
+## The Reinvestment Cycle
+Often, companies emerge in an opposite way - find a broad problem, create a solution, and then go down customization rabbit holes to fit it to clients' exact needs. What kind of company could we build if we reversed that learning reinvestment?
+
+The cycle could be:
+1. **Deep Work**: Solve complex problem for 1 client (e.g., billing workflow for a PT client)
+2. **Extract Pattern**: Identify the reusable core (e.g., agent launcher framework)
+3. **Broaden Application**: Find 50+ others with same need, productize the solution
+
+### The Distribution Test
+
+**New year bet**: If we take an agency client on, and we:
+1. Identify 50+ other organizations with the same problem
+2. Build the solution with reusability in mind
+3. Extract and market a generic version
+
+This forces intentional learning reinvestment from the start. Could we build a set of tools that are extremely relevant to the average knowledge worker who wants to get back to doing the parts of the job they love? Give people the tools to spend their time making real impact, and let the robots do the repeatable work? That's the bet.
+
+## Related Concepts
+
+- [[Tour of Duty in the AI Era]] - Deep engagements that extract transferable patterns
+- [[Pricing for Value Instead of Time]] - How to structure compensation around this cycle
+- The tension between depth and distribution
+- Why agency work doesn't naturally create leverage without intentional pattern extraction
+- Every's Master Plan Part I Triangle: https://every.to/on-every/every-s-master-plan

--- a/_notes/distribution-vs-depth.md
+++ b/_notes/distribution-vs-depth.md
@@ -4,6 +4,9 @@ title: "Distribution vs Depth: Thoughts on Learning Reinvestment"
 date: 2025-01-15
 tags: [leverage, learning, consulting, productization, agency-work]
 attribution: human-written
+status: seed
+authors: ["Marcy Ewald"]
+summary: "<How to extend deep, specific learning into broad applications in consulting work.>"
 ---
 
 We love our agency clients, and we love building bespoke answers to their specific needs. But, as we think about the next phase of ThinkNimble and how to extend our impact beyond the hundreds of excellent entrepreneurs we've worked with, we're asking: how can we use the Agency for a larger good? We've built hundreds of apps and provided leverage to our entreprenuers. We've learned a lot along the way. But for every learning we've had, it's extremely difficult to reinvest it. How do you extract the deep, narrow insights from bespoke client work and transform them into broadly applicable solutions? If we could do that well, how would that change our scale of impact?

--- a/_notes/infinite-ui-team-discussion.md
+++ b/_notes/infinite-ui-team-discussion.md
@@ -5,6 +5,7 @@ date: 2025-09-07
 updated: 2025-09-07
 tags: [ui-paradigm, team-discussion, ai-interfaces, product-design, state-space]
 attribution: human-written
+status: budding
 authors: ["William Huster", "Neil Shah", "Marcy Ewald"]
 published: false
 ---

--- a/_notes/pricing-value-not-time.md
+++ b/_notes/pricing-value-not-time.md
@@ -4,6 +4,9 @@ title: "Pricing for Value Instead of Time"
 date: 2025-01-15
 tags: [future-of-work, consulting, pricing, value-creation]
 attribution: ai-supported
+status: seed
+authors: ["Marcy Ewald"]
+summary: <Pricing not just time, but value.>"
 ---
 
 Peter and I were brainstorming last week, mostly circling around how to charge for expertise when AI makes hourly pricing obsolete.

--- a/_notes/pricing-value-not-time.md
+++ b/_notes/pricing-value-not-time.md
@@ -1,0 +1,84 @@
+---
+layout: note
+title: "Pricing for Value Instead of Time"
+date: 2025-01-15
+tags: [future-of-work, consulting, pricing, value-creation]
+attribution: ai-supported
+---
+
+Peter and I were brainstorming last week, mostly circling around how to charge for expertise when AI makes hourly pricing obsolete.
+
+Here's the problem: Half the MVPs we used to build can be vibe coded. Half the other half can use a good one shot prompt, some compelling UX, and excellent evals, and can solve problems that used to be only solvable by humans. If it takes me 2 months to deliver an MVP instead of 4, should I charge half as much? (I know, a lot of halves for one whole). 
+
+Maybe, if the rest of the industry has the same expertise as I do and can compete directly. Maybe, if I'm charging on hours. But, I think I'm actually now delivering value very few others can. How do I charge for that?
+
+The traditional models are breaking:
+- **W2 employment**: Paid for time and "potential" over 30 years
+- **1099 contracting**: Paid for deliverables, usually small engagements
+- **Consulting**: Paid by the hour, directly punishing efficiency
+
+None of these capture what AI-augmented workers actually deliver: compressed timelines, specialized knowledge, and outcomes that don't correlate with hours.
+
+## The Dark Side of the Moon Problem
+
+We're thinking about this, and how to prove we have value. How does one pre-show value that is like seeing the dark side of the moon?
+
+Sometimes, our work ends in failed startups. Because well, startups fail. But perhaps they failed faster with our help, so the entrepreneur could move onto their next thing with new experience. Perhaps we built a piece of tech that solved a real problem for 5 people, but just couldn't make it into a business. Perhaps we helped a startup avoid a bunch of mistakes that would have ended them sooner.
+
+There's no way to show the branching versions of the universe that happened when a startup chose to work with us over another shop. But they're there. They're real. They're in the testimonials, how much we know about each industry we've touched, the relationships we've built with our clients. We've become experts at helping real knowledge workers become real entrepreneurs.
+
+Translating that dark side of the moon into value-based pricing is a struggle. We'll keep you posted on how it's going.
+
+## Five Dimensions of Value
+
+If we start to break down the value we provide outside of hours worked, it gets messy, quick. But here's one version that looks at value across five dimensions. For ThinkNimble [we've taken dozens pre-revenue companies through their seed rounds], that looks like: 
+
+**1. Knowledge & Learning Value** (10-30% premium)
+- Multiple hypotheses to test rapidly
+- High pivot probability requiring flexibility
+- Unknown market dynamics requiring exploration
+- The value of preventing 6-12 months building the wrong thing
+
+**2. Speed to Market Premium** (15-50% premium)
+- Racing competitors to market position
+- Event/demo deadlines (investor meetings, conferences)
+- Seasonal opportunity windows
+- Compressed delivery timelines
+
+**3. Future Option Value** (10-25% premium)
+- Platform potential (not just single product)
+- API/ecosystem play possibilities
+- Multiple customer segment opportunities
+- Building flexibility for future pivots
+
+**4. Funding Catalyst Value** (20-30% of funding target)
+- Active investor conversations requiring demo
+- Traction proof needed for raise
+- Fundable prototype that demonstrates viability
+- Typically 2-5% of next funding round target
+
+**5. Risk Mitigation Value** (10-25% premium)
+- High technical uncertainty de-risking
+- Regulatory complexity navigation
+- First-time founder knowledge transfer
+- Strategic insights that prevent expensive mistakes
+
+**Traditional Model:**
+- 400 hours × $150/hr = $60,000
+
+**Value-Based Model:**
+So, if we charge on value, not time, where does that leave us?
+- Base development: $60,000
+- Knowledge premium (+20%): $12,000
+- Speed premium (+25%): $15,000
+- Option value (+15%): $9,000
+- Funding catalyst (2% of $500K raise): $10,000
+- Risk mitigation (+10%): $6,000
+- **Total: $112,000 (1.87x multiplier)**
+
+The frame: "You're not buying hours. You're buying the learning that prevents building the wrong thing, the speed that captures market timing, and the optionality that enables your next three pivots." Will that work in the real world? I don't know. But we are thinking about it, and others who have deep expertise are too. I think we'll see major changes in outcomes based pricing, especially in tech, in the next 2-3 years.
+
+
+## Related Concepts
+
+- [[Tour of Duty in the AI Era]] - How sports-style career mobility enables this pricing model, including how workers negotiate agent development time as part of engagement compensation

--- a/_notes/tour-of-duty-ai-era.md
+++ b/_notes/tour-of-duty-ai-era.md
@@ -1,0 +1,167 @@
+---
+layout: note
+title: "Tour of Duty in the AI Era"
+date: 2025-01-15
+tags: [future-of-work, labor-markets, consulting, ai-augmentation]
+attribution: human-written
+---
+
+
+> We wrote about our concept of [tours of duty a few years ago](https://medium.com/the-business-of-tech/tours-of-duty-d4089fa9a490), and have been mulling over how to update it in the new world of AI-assisted productivty, and changes in hiring, retention, and consolidation of capital in a very few, large conglomerates. 
+
+We expect that the trend toward consolidation of resources in the hands of a few (think FANG, but with an AI spin) will continue. There will be long-tail careers available in large companies, but there will also be a huge market for talent grabbing. [there's a lot of evidence on this, from insane signing bonsues for AI talent, to layoffs of middle management. Note to self to gather these so it's easy to see what we've been reading].
+
+That brings experience and excellence, but also the grind: client management, transcribing your vision into executable tasks, the boredom of work you used to delegate.
+
+It also brings up some ideas about how creating AI agents to take the workload that is delegable and taking those agents as a part of your whole work package, could be a trend we're headed toward.
+
+Looking back the the original framework we had for how 30 year careers with a single company was being transformed, I can imagine there's a third path opening in the world of AI. First - a trip back to the framework we adapted.
+
+## The Original Framework (2019)
+
+From our [earlier work on tours of duty](https://medium.com/the-business-of-tech/tours-of-duty-d4089fa9a490):
+
+> We started rolling out specific tours of duties a couple of years ago, and it's really helped us define success for each arc of an employee's time with us. Employees are generally happy to sign up for a one or two-year intentional investment (still at will, of course) rather than an undefined purgatory of work. And it has helped me see my company as a place to not just do good work for our clients, but be a stepping stone for our team to help them succeed.
+>
+> To kick off this experiment, we began defining success anecdotally. We realistically defined what we anticipated an employee could accomplish in 1–2 years that strengthened skills they were interested in exercising or built new skills they were interested in honing in their career.
+>
+> That looked something like this:
+>
+> **Our business needs to [insert part of the business here], and you have [insert already-proven skills here] that we know will help. You're looking to [area of growth], and we believe [business area] will benefit from you growing those skills.**
+>
+> That framework was a major game-changer.
+>
+> These smaller arcs helped us understand how to invest in the team member, and helped our team members understand why we needed that role filled by them.
+>
+> Recently, we've gotten clearer on the actual numbers behind that investment, and their impact on pieces of our business (revenue, speed to delivery, customer value, etc.). We're slowly starting to share this with our team, hoping it helps our team understand the risks and rewards we're evaluating as we collectively invest in the tour of duty together.
+
+**Our take on tours of duty (2019 version):**
+1. Define what someone could actually accomplish in 2 years (skills they bring to the table, skills they'll work on, etc.)
+2. Then, once you're clearer on the small things people can accomplish in 2 years, figure out how that translates to revenue.
+3. You can do 1 without 2, but if you do 1, at some point, 2 will become clear to you, and you'll want to share it with them.
+
+
+## Agents as Hiring Signal
+
+<div class="conversation">
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">Sep 5th at 11:48 AM</span>
+    <p>random idea of the day -- what if when we hired again we asked people to bring their suite of agents that supports their work</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Sueah</strong><span class="conversation-timestamp">11:48</span>
+    <p>omgg</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Sueah</strong><span class="conversation-timestamp">11:49</span>
+    <p>because we can see how they breakdown and think about how to do their jobs</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Sueah</strong><span class="conversation-timestamp">11:49</span>
+    <p>the only thing we actually care about - how do you think about the work</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">11:49</span>
+    <p>it's like bringing your whole team to a job in the olden days</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">11:49</span>
+    <p> "i'll come but only if you hire my secretary and also my direct report"</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">11:50</span>
+    <p>and now its' "ya but here's how i do my work, this is my little agent that writes weekly updates, and my little prd guy, and my little reminder to drink water agent"</p>
+  </div>
+</div>
+
+**What could a Tour of Duty look like? (2026 version):**
+1. Define what zone of genius someone has demonstrated (agents who support them, wins on their resume, etc.)
+2. Understand the gaps in your competitive strategy, and whether that person plays a role in the team you need to win the next game.
+
+[link to infinite games]
+
+
+
+## The Sports Model: A Third Path
+
+Professional sports already work this way:
+- Athletes are constantly traded between teams
+- They bring specific, concentrated expertise
+- Compensation is front-loaded into peak years (10 years of high earnings vs. 30 years of moderate earnings)
+- The compressed earnings support career pivots when demand for their skills drops
+
+You bring a set of skills that fit an organization in a specific state, get paid well to "win games" together, then reinvest to retrain for the next org. You move from player, to coach, to owner. Both parties benefit from the trade when your skills and their needs overlap.
+
+
+<div class="conversation">
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">10:56</span>
+    <p>part of what's hard is that as a contractor you're hired on value / outcomes, but not on inputs. as a w2, you're hired on "potential for impact". but there's all these experts now in this world (and there will be more) who can't provide 30 year value to a company, but their potential is super high, so they miss both the w2 and the 1099 train. one of the trends we've seen is hard it is to operate outside the big 100 companies, and we've been thinking about how we can play a role in the disaggregation of that economic accumulation. <</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">10:57</span>
+    <p>and Peter said, extremely interestinly, that sports actually works like that now</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Sueah</strong><span class="conversation-timestamp">10:57</span>
+    <p>PGA expertise coming to play!</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">10:57</span>
+    <p>so you are constantly traded between [companies] and you bring [WR expertise] and you get extreme compensation over a 3-10 year period. the old model has us thinking about careers as less money per year over a 30 year period, nstead of a lot of money in a 10 year period that supports the other 20 years.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">10:59</span>
+    <p>but the interesting part / overlap is if you could convince people to be "traded" that way we could kind of open up a third path, and if you could convince companies to offer ways to compensate people for what they bring culturally to the position (the ted lasso's) or skill wise (the mahomes), then you could kind of restructure the working economy</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">11:01</span>
+    <p>like if instead of working on a specific client for a fraction of our time, we are actually employed there for 6 months, we make a lot of money during that period because they have a lot of wins, and then we're off for 6 months to retrain for the next client.</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Sueah</strong><span class="conversation-timestamp">11:02</span>
+    <p>consulting+ but instead of a deck and a recommendation to fire everyone, we actually build something during that time</p>
+  </div>
+
+  <div class="conversation-message">
+    <strong>Marcy</strong><span class="conversation-timestamp">11:03</span>
+    <p>exactly, I could go to a startup and say "you need someone who's built a product process three times, has zero interest in working here long term because they have no interest in working for a large org, and will be traded to another team as soon as you both win this Super Bowl.</p>
+  </div>
+
+
+## Tours of [Traded] Duty
+
+
+Deep engagement model where experts:
+- Embed for concentrated periods (e.g., 6 months on, 6 months off)
+- Actually build and implement solutions
+- Bring proven expertise from multiple similar engagements
+- Command premium compensation for compressed delivery
+- Move on when the specific expertise is no longer the bottleneck
+
+
+
+## Open Questions
+
+- How do we structure compensation for "tour of duty" engagements that reflect both the compressed timeline and the premium value? [link to the value note]
+- What can companies provide culturally to make workers comfortable with being "traded" between companies?
+- How do companies evaluate and compensate both technical expertise (the specialist) and cultural impact (the culture-builder)?
+- Could this model work only outside the top 100 companies? Does it only work if the top 100 companies participate and "fund" it?
+- What role does AI augmentation play in making shorter, higher-impact engagements possible?
+
+## Related Concepts
+
+- [[Pricing for Value Instead of Time]] - How to structure compensation for this model
+- [[Agency of Agents]] as a potential structure for this model

--- a/_notes/tour-of-duty-ai-era.md
+++ b/_notes/tour-of-duty-ai-era.md
@@ -4,6 +4,9 @@ title: "Tour of Duty in the AI Era"
 date: 2025-01-15
 tags: [future-of-work, labor-markets, consulting, ai-augmentation]
 attribution: human-written
+status: budding
+authors: ["Marcy Ewald"]
+summary: "<A new way of thinking about your career path.>"
 ---
 
 
@@ -143,15 +146,12 @@ You bring a set of skills that fit an organization in a specific state, get paid
 
 ## Tours of [Traded] Duty
 
-
 Deep engagement model where experts:
 - Embed for concentrated periods (e.g., 6 months on, 6 months off)
 - Actually build and implement solutions
 - Bring proven expertise from multiple similar engagements
 - Command premium compensation for compressed delivery
 - Move on when the specific expertise is no longer the bottleneck
-
-
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

Adding three interconnected research notes exploring how AI is reshaping work, pricing, and career structures:

1. **Tour of Duty in the AI Era** - Explores sports-style career mobility as a third path between W2 and 1099, agent portfolios as hiring signals, and the "consulting+" model of tours of traded duty

2. **Pricing for Value Instead of Time** - Introduces a five-dimensional framework for value-based pricing that accounts for knowledge/learning value, speed premiums, option value, funding catalysts, and risk mitigation

3. **Distribution vs Depth** - Examines the learning reinvestment cycle and tension between deep agency work and scaled products, with frameworks for extracting patterns from bespoke solutions

All three notes include Slack conversations showing our thinking process and contain wiki-style links to each other.

## Attribution

- tour-of-duty-ai-era.md: human-written (Slack conversations + context)
- pricing-value-not-time.md: ai-supported (collaborative drafting)
- distribution-vs-depth.md: human-written (Slack conversations + framing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)